### PR TITLE
Add slice for homepage graphs

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -1,13 +1,16 @@
-function generatePlayerGraph(player) {
+function generatePlayerGraph(player, sample = 0) {
   const ctx = document.getElementById(player.name).getContext("2d");
+
+  const eloHistory = (sample && sample < player.eloHistory.length) ? player.eloHistory.slice(-sample) : player.eloHistory
+
   const playerGraph = new window.Chart(ctx, {
     type: "line",
     data: {
-      labels: player.eloHistory.map(() => ""), // required
+      labels: eloHistory.map(() => ""), // required
       datasets: [
         {
           label: "ELO",
-          data: player.eloHistory.map(e => e),
+          data: eloHistory.map(e => e),
           fill: false,
           borderColor: "rgb(75, 192, 192)",
           lineTension: 0.1

--- a/public/stats.js
+++ b/public/stats.js
@@ -43,6 +43,6 @@ fetch("/stats")
 </div>`;
 
       statsList.appendChild(newListItem);
-      window.generatePlayerGraph(player);
+      window.generatePlayerGraph(player, 25);
     }
   });


### PR DESCRIPTION
Only the most recent 25 games will be shown on the player graph for players with more than 25 games played.

Default parameter added for `generatePlayerGraph(player, sample = 0)`  and `window.generatePlayerGraph(player, 25)` for the homepage in `stats.js`. 

Ternary `const eloHistory = (sample && sample < player.eloHistory.length) ? player.eloHistory.slice(-sample) : player.eloHistory` added to take a final slice of games to display on graph if the player has more games played than slice.